### PR TITLE
 Generalize event list loading

### DIFF
--- a/setup/setup.bash
+++ b/setup/setup.bash
@@ -143,14 +143,13 @@ else
 fi
 source activate dave
 
-
-#Installing Stingray
+#Installing Stingray and Astropy Helpers
 STINGRAY_FOLDER=$DIR/stingray
 STINGRAY_URL=https://github.com/StingraySoftware/stingray.git
 # Sets the specific commit to checkout:
 # Jul 26, 2017 -> https://github.com/StingraySoftware/stingray/commit/6f21046cc6daf7b5db6813525eb1f7c54fc1b2a1
 STINGRAY_COMMIT_HASH=6f21046cc6daf7b5db6813525eb1f7c54fc1b2a1
-
+DARWIN_COMPILATION=lib.macosx-10.5-x86_64-3.5
 if [ ! -e $STINGRAY_FOLDER ]; then
 
 	echo Installing Stingray
@@ -197,7 +196,6 @@ if [ ! -e $STINGRAY_FOLDER ]; then
 		cd $DIR/..
 
 		# Copy built libraries to python project
-		DARWIN_COMPILATION=lib.macosx-10.5-x86_64-3.5
 		\cp -r $STINGRAY_FOLDER/build/$DARWIN_COMPILATION/stingray src/main/python
 		\cp -r $STINGRAY_FOLDER/astropy_helpers/build/$DARWIN_COMPILATION/astropy_helpers src/main/python
 	fi
@@ -230,16 +228,8 @@ if [ ! -e $MALTPYNT_FOLDER ]; then
 		#Build MALTPYNT
 		python setup.py install
 
-		cd $MALTPYNT_FOLDER/astropy_helpers
-
-		#Build astropy_helpers
-		python setup.py install
-
-		cd $DIR/..
-
 		# Copy built libraries to python project
 		\cp -r $MALTPYNT_FOLDER/build/lib.linux-x86_64-3.5/maltpynt src/main/python
-		\cp -r $MALTPYNT_FOLDER/astropy_helpers/build/lib.linux-x86_64-3.5/astropy_helpers src/main/python
 
 	elif [[ "$OSTYPE" == "darwin"* ]]; then
 		# Mac OSX
@@ -247,19 +237,11 @@ if [ ! -e $MALTPYNT_FOLDER ]; then
 		#Build MALTPYNT
 		sudo python setup.py install
 
-		cd $MALTPYNT_FOLDER/astropy_helpers
-
-		#Build astropy_helpers
-		sudo python setup.py install
-
-		cd $DIR/..
-
 		# Copy built libraries to python project
-		DARWIN_COMPILATION=lib.macosx-10.5-x86_64-3.5
 		\cp -r $MALTPYNT_FOLDER/build/$DARWIN_COMPILATION/maltpynt src/main/python
-		\cp -r $MALTPYNT_FOLDER/astropy_helpers/build/$DARWIN_COMPILATION/astropy_helpers src/main/python
 	fi
 fi
+
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	# Mac OSX
@@ -273,6 +255,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
 	/usr/local/bin/brew install libmagic
 fi
+
 
 # Installing node modules
 echo Installing node modules

--- a/setup/setup.bash
+++ b/setup/setup.bash
@@ -164,6 +164,7 @@ if [ ! -e $STINGRAY_FOLDER ]; then
 
 	#Install stingray libraries
 	pip install -r requirements.txt
+	pip install statsmodels
 
 	if [[ "$OSTYPE" == "linux-gnu" ]]; then
 		#Linux

--- a/setup/setup.bash
+++ b/setup/setup.bash
@@ -202,6 +202,64 @@ if [ ! -e $STINGRAY_FOLDER ]; then
 	fi
 fi
 
+#Installing Maltpynt
+MALTPYNT_FOLDER=$DIR/maltpynt
+MALTPYNT_URL=https://github.com/StingraySoftware/MaLTPyNT_reboot.git
+# Sets the specific commit to checkout:
+# Aug 1st, 2017 -> https://github.com/StingraySoftware/MaLTPyNT_reboot/commit/d53d36492061dbffa4ad9db478dd5bbcfd7e2f62
+MALTPYNT_COMMIT_HASH=d53d36492061dbffa4ad9db478dd5bbcfd7e2f62
+
+if [ ! -e $MALTPYNT_FOLDER ]; then
+
+	echo Installing MALTPYNT
+	git clone --recursive $MALTPYNT_URL $MALTPYNT_FOLDER
+
+	cd $MALTPYNT_FOLDER
+
+	# Gets specific commit version
+	echo Getting specific version of MALTPYNT
+	git checkout $MALTPYNT_COMMIT_HASH
+
+	#Install MALTPYNT libraries
+	pip install -r requirements.txt
+
+	if [[ "$OSTYPE" == "linux-gnu" ]]; then
+		#Linux
+
+		#Build MALTPYNT
+		python setup.py install
+
+		cd $MALTPYNT_FOLDER/astropy_helpers
+
+		#Build astropy_helpers
+		python setup.py install
+
+		cd $DIR/..
+
+		# Copy built libraries to python project
+		\cp -r $MALTPYNT_FOLDER/build/lib.linux-x86_64-3.5/maltpynt src/main/python
+		\cp -r $MALTPYNT_FOLDER/astropy_helpers/build/lib.linux-x86_64-3.5/astropy_helpers src/main/python
+
+	elif [[ "$OSTYPE" == "darwin"* ]]; then
+		# Mac OSX
+
+		#Build MALTPYNT
+		sudo python setup.py install
+
+		cd $MALTPYNT_FOLDER/astropy_helpers
+
+		#Build astropy_helpers
+		sudo python setup.py install
+
+		cd $DIR/..
+
+		# Copy built libraries to python project
+		DARWIN_COMPILATION=lib.macosx-10.5-x86_64-3.5
+		\cp -r $MALTPYNT_FOLDER/build/$DARWIN_COMPILATION/maltpynt src/main/python
+		\cp -r $MALTPYNT_FOLDER/astropy_helpers/build/$DARWIN_COMPILATION/astropy_helpers src/main/python
+	fi
+fi
+
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	# Mac OSX
 	#This is for MagicFile not for styngray, but only applies to macosx

--- a/src/main/python/.gitignore
+++ b/src/main/python/.gitignore
@@ -1,3 +1,4 @@
 uploadeddataset/
 astropy_helpers/
 stingray/
+maltpynt/

--- a/src/main/python/utils/dataset_helper.py
+++ b/src/main/python/utils/dataset_helper.py
@@ -15,6 +15,8 @@ def get_eventlist_from_evt_dataset(dataset):
         logging.warn("get_eventlist_from_evt_dataset: dataset is not a events dataset instance")
         return None
 
+    # TODO: Probably all this check can be moved to dave_reader for doing it only once
+    # instead with every call to get_eventlist_from_evt_dataset
     if not "PHA" in dataset.tables["EVENTS"].columns:
         logging.warn("get_eventlist_from_evt_dataset: PHA column not found in dataset")
         dataset.tables["EVENTS"].add_columns(["PHA"])

--- a/src/main/python/utils/dataset_helper.py
+++ b/src/main/python/utils/dataset_helper.py
@@ -17,7 +17,16 @@ def get_eventlist_from_evt_dataset(dataset):
 
     if not "PHA" in dataset.tables["EVENTS"].columns:
         logging.warn("get_eventlist_from_evt_dataset: PHA column not found in dataset")
-        return None
+        dataset.tables["EVENTS"].add_columns(["PHA"])
+        try:
+            dataset.tables["EVENTS"].columns["PHA"].values = \
+                dataset.tables["EVENTS"].columns["PI"].values
+            logging.warn("Using PI instead of PHA")
+        except:
+            dataset.tables["EVENTS"].columns["PHA"].values = \
+                np.zeros(len(dataset.tables["EVENTS"].columns["TIME"].values),
+                         dtype=int)
+            logging.warn("PHA column will be empty")
 
     # Extract axis values
     time_data = np.array(dataset.tables["EVENTS"].columns["TIME"].values)

--- a/src/main/python/utils/dave_reader.py
+++ b/src/main/python/utils/dave_reader.py
@@ -51,7 +51,7 @@ def get_file_dataset(destination):
         # Opening Fits
         hdulist = fits.open(destination, memmap=True)
         dataset = None
-        
+
         if 'EVENTS' in hdulist:
             # If EVENTS extension found, consider the Fits as EVENTS Fits
             dataset = get_events_fits_dataset_with_stingray(destination, hdulist, dsId='FITS',
@@ -168,7 +168,6 @@ def get_events_fits_dataset_with_stingray(destination, hdulist, dsId='FITS',
                                      gtistring=gtistring,
                                      hduname=hduname, column=column)
 
-    logging.warn(repr(fits_data.additional_data))
     # Adds the lag of the first event to the start time of observation
     events_start_time = fits_data.t_start
     event_list = fits_data.ev_list
@@ -177,7 +176,6 @@ def get_events_fits_dataset_with_stingray(destination, hdulist, dsId='FITS',
     gti_end = event_list.gti[:, 1] - events_start_time
 
     logging.debug("Read Events fits... gti_start: " + str(len(gti_start)) + ", gti_end: " + str(len(gti_end)))
-
 
     event_values = event_list.time - events_start_time
 

--- a/src/main/python/utils/dave_reader.py
+++ b/src/main/python/utils/dave_reader.py
@@ -6,7 +6,7 @@ import magic
 import model.dataset as DataSet
 import numpy as np
 from astropy.io import fits
-from stingray.io import load_events_and_gtis
+from maltpynt.io import load_events_and_gtis
 from stingray.gti import _get_gti_from_extension
 from utils.stingray_addons import lcurve_from_fits
 import utils.dataset_cache as DsCache
@@ -151,11 +151,6 @@ def get_events_fits_dataset_with_stingray(destination, hdulist, dsId='FITS',
 
     header, header_comments = get_header(hdulist, hduname)
 
-    # Gets start time of observation
-    events_start_time = 0
-    if "TSTART" in header:
-        events_start_time = hdulist[hduname].header["TSTART"]  # Avoid use header directly, has wrong data type
-
     # Closes the FITS file, further file data reads will be done via Stingray
     hdulist.close()
 
@@ -168,20 +163,23 @@ def get_events_fits_dataset_with_stingray(destination, hdulist, dsId='FITS',
 
     # Reads fits data
     logging.debug("Reading Events Fits columns's data")
-    fits_data = load_events_and_gtis(destination, additional_columns=additional_columns,
-                                    gtistring=gtistring,
-                                    hduname=hduname, column=column)
+    fits_data = load_events_and_gtis(destination,
+                                     additional_columns=additional_columns,
+                                     gtistring=gtistring,
+                                     hduname=hduname, column=column)
 
+    logging.warn(repr(fits_data.additional_data))
     # Adds the lag of the first event to the start time of observation
-    events_start_time += max(fits_data.ev_list[0] - events_start_time, 0)
+    events_start_time = fits_data.t_start
+    event_list = fits_data.ev_list
 
-    gti_start = fits_data.gti_list[:, 0] - events_start_time
-    gti_end = fits_data.gti_list[:, 1] - events_start_time
+    gti_start = event_list.gti[:, 0] - events_start_time
+    gti_end = event_list.gti[:, 1] - events_start_time
 
     logging.debug("Read Events fits... gti_start: " + str(len(gti_start)) + ", gti_end: " + str(len(gti_end)))
 
-    event_values = fits_data.ev_list - events_start_time
-    event_values[0] = 0 # This is because double substraction could return small negative values for 0
+
+    event_values = event_list.time - events_start_time
 
     dataset = DataSet.get_dataset_applying_gtis(dsId, header, header_comments,
                                                 fits_data.additional_data, [],


### PR DESCRIPTION
- [x] Use maltpynt's load_events_and_gtis, as it understands better different file formats.. like which GTI extension(s) to use in XMM files! (GTIs change for every detector of PN, for example)
- [x] Use TSTART as time reference (please)
- [x] Exit gracefully if PHA column not present in files
- [x] Add maltpynt installation to setup
