### PR TITLE
DAVE-363: Upgrade version of node to current LTS version

### DIFF
--- a/setup/setup.bash
+++ b/setup/setup.bash
@@ -79,7 +79,7 @@ fi
 export PATH=${PATH}:${INSTALL_DIR}/bin
 
 # Install node.js
-NODE_VERSION=4.4.4
+NODE_VERSION=7.9.0
 NODE_FILENAME="node-v$NODE_VERSION"
 
 	if [[ "$OSTYPE" == "linux-gnu" ]]; then
@@ -114,12 +114,13 @@ NODE_FILENAME="node-v$NODE_VERSION"
 			retVal=$?
 			if [[ retVal -ne 0 ]] ; then
 				rm $NODE_TAR
-				echo "Can't download NODE fro Mac OSX!!!"
+				echo "Can't download NODE for Mac OSX!!!"
 				return 1
 			fi
 		fi
 
-		installer -pkg $NODE_TAR -target /
+		echo "Please type your root password for installing Node"
+		sudo installer -pkg $NODE_TAR -target /
 
 	else
 		# Unknown.

--- a/src/main/js/electron/package.json
+++ b/src/main/js/electron/package.json
@@ -11,12 +11,12 @@
   },
   "dependencies": {
     "config-js": "^1.1.9",
-    "electron-packager": "^8.5.0",
+    "electron-packager": "^10.1.1",
     "menu": "^0.2.5",
     "request": "^2.79.0",
     "request-promise": "*"
   },
   "devDependencies": {
-    "electron": "^1.4.14"
+    "electron": "^1.7.10"
   }
 }


### PR DESCRIPTION
Updated Node to v7.9.0, Electron to 1.7.10 and ElectronPackager to 10.1.1. Tested both on MacOS and Linux. Now DAVE looks smoother and faster 